### PR TITLE
Move some AAC tables to RAM, speed up decode 17%

### DIFF
--- a/src/libhelix-aac/sbr.h
+++ b/src/libhelix-aac/sbr.h
@@ -179,7 +179,7 @@ enum {
 
 typedef struct _HuffInfo {
     int maxBits;							/* number of bits in longest codeword */
-    unsigned /*char*/ int count[MAX_HUFF_BITS];		/* count[i] = number of codes with length i+1 bits */
+    unsigned char count[MAX_HUFF_BITS];		/* count[i] = number of codes with length i+1 bits */
     int offset;								/* offset into symbol table */
 } HuffInfo;
 
@@ -374,7 +374,7 @@ extern const unsigned char k0Tab[NUM_SAMPLE_RATES_SBR][16];
 extern const unsigned char k2Tab[NUM_SAMPLE_RATES_SBR][14];
 extern const unsigned char goalSBTab[NUM_SAMPLE_RATES_SBR];
 extern const HuffInfo huffTabSBRInfo[10];
-extern const signed int /*short*/ huffTabSBR[604];
+extern const signed short huffTabSBR[604];
 extern const int log2Tab[65];
 extern const int noiseTab[512 * 2];
 extern const int cTabA[165];

--- a/src/libhelix-aac/sbrhuff.c
+++ b/src/libhelix-aac/sbrhuff.c
@@ -66,10 +66,10 @@
                   if there are no codes at nBits, then we just keep << 1 each time
                     (since count[nBits] = 0)
  **************************************************************************************/
-static int DecodeHuffmanScalar(const signed /*short*/ int *huffTab, const HuffInfo *huffTabInfo, unsigned int bitBuf, signed int *val) {
+static int DecodeHuffmanScalar(const signed short int *huffTab, const HuffInfo *huffTabInfo, unsigned int bitBuf, signed int *val) {
     unsigned int count, start, shift, t;
-    const unsigned int /*char*/ *countPtr;
-    const signed int /*short*/ *map;
+    const unsigned char *countPtr;
+    const signed short *map;
 
     map = huffTab + huffTabInfo->offset;
     countPtr = huffTabInfo->count;

--- a/src/libhelix-aac/sbrtabs.c
+++ b/src/libhelix-aac/sbrtabs.c
@@ -46,6 +46,8 @@
 
 #include "sbr.h"
 
+#define DPROGMEM __attribute__(( section(".data") ))
+
 /*  k0Tab[sampRateIdx][k] = k0 = startMin + offset(bs_start_freq) for given sample rate (4.6.18.3.2.1)
     downsampled (single-rate) SBR not currently supported
 */
@@ -98,7 +100,7 @@ const HuffInfo huffTabSBRInfo[10] PROGMEM = {
 };
 
 /* Huffman tables from appendix 4.A.6.1, includes offset of -LAV[i] for table i */
-const signed int /*short*/ huffTabSBR[604] PROGMEM = {
+const signed short huffTabSBR[604] PROGMEM = {
     /* SBR table sbr_tenv15 [121] (signed) */
     0,   -1,    1,   -2,    2,   -3,    3,   -4,    4,   -5,    5,   -6,    6,   -7,    7,   -8,
     -9,    8,  -10,    9,  -11,   10,  -12,  -13,   11,  -14,   12,  -15,  -16,   13,  -19,  -18,

--- a/src/libhelix-aac/trigtabs.c
+++ b/src/libhelix-aac/trigtabs.c
@@ -48,7 +48,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 
-const int cos4sin4tabOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
+#define DPROGMEM __attribute__(( section(".data") ))
+
+const int cos4sin4tabOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 
 /*  PreMultiply() tables
     format = Q30 * 2^[-7, -10] for nmdct = [128, 1024]
@@ -65,7 +67,7 @@ const int cos4sin4tabOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
      x = invM * sin(angle);
     }
 */
-const int cos4sin4tab[128 + 1024] PROGMEM = {
+const int cos4sin4tab[128 + 1024] DPROGMEM = {
     /* 128 - format = Q30 * 2^-7 */
     0xbf9bc731, 0xff9b783c, 0xbed5332c, 0xc002c697, 0xbe112251, 0xfe096c8d, 0xbd4f9c30, 0xc00f1c4a,
     0xbc90a83f, 0xfc77ae5e, 0xbbd44dd9, 0xc0254e27, 0xbb1a9443, 0xfae67ba2, 0xba6382a6, 0xc04558c0,
@@ -225,7 +227,7 @@ const int cos4sin4tab[128 + 1024] PROGMEM = {
      x = sin(angle);
     }
 */
-const int cos1sin1tab[514] PROGMEM = {
+const int cos1sin1tab[514] DPROGMEM = {
     /* format = Q30 */
     0x40000000, 0x00000000, 0x40323034, 0x003243f1, 0x406438cf, 0x006487c4, 0x409619b2, 0x0096cb58,
     0x40c7d2bd, 0x00c90e90, 0x40f963d3, 0x00fb514b, 0x412accd4, 0x012d936c, 0x415c0da3, 0x015fd4d2,
@@ -294,7 +296,7 @@ const int cos1sin1tab[514] PROGMEM = {
     0x5a82799a, 0x2d413ccd,
 };
 
-const int sinWindowOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
+const int sinWindowOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 
 /*  Synthesis window - SIN
     format = Q31 for nmdct = [128, 1024]
@@ -457,7 +459,7 @@ const int sinWindow[128 + 1024] PROGMEM = {
     0x5a05bdae, 0x5afe8a8b, 0x5a29727b, 0x5adb297d, 0x5a4d1960, 0x5ab7ba6c, 0x5a70b258, 0x5a943d5e,
 };
 
-const int kbdWindowOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
+const int kbdWindowOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 
 /*  Synthesis window - KBD
     format = Q31 for nmdct = [128, 1024]
@@ -623,9 +625,9 @@ const int kbdWindow[128 + 1024] PROGMEM = {
 
 /* bit reverse tables for FFT */
 
-const int bitrevtabOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 17};
+const int bitrevtabOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 17};
 
-const unsigned char bitrevtab[17 + 129] PROGMEM = {
+const unsigned char bitrevtab[17 + 129] DPROGMEM = {
     /* nfft = 64 */
     0x01, 0x08, 0x02, 0x04, 0x03, 0x0c, 0x05, 0x0a, 0x07, 0x0e, 0x0b, 0x0d, 0x00, 0x06, 0x09, 0x0f,
     0x00,
@@ -643,7 +645,7 @@ const unsigned char bitrevtab[17 + 129] PROGMEM = {
 
 };
 
-const unsigned char uniqueIDTab[8] = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 0x5f};
+const unsigned char uniqueIDTab[8] DPROGMEM = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 0x5f};
 
 /*  Twiddle tables for FFT
     format = Q30
@@ -685,7 +687,7 @@ const unsigned char uniqueIDTab[8] = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 
      }
     }
 */
-const int twidTabOdd[8 * 6 + 32 * 6 + 128 * 6] PROGMEM = {
+const int twidTabOdd[8 * 6 + 32 * 6 + 128 * 6] DPROGMEM = {
     0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x539eba45, 0xe7821d59,
     0x4b418bbe, 0xf383a3e2, 0x58c542c5, 0xdc71898d, 0x5a82799a, 0xd2bec333, 0x539eba45, 0xe7821d59,
     0x539eba45, 0xc4df2862, 0x539eba45, 0xc4df2862, 0x58c542c5, 0xdc71898d, 0x3248d382, 0xc13ad060,
@@ -816,7 +818,7 @@ const int twidTabOdd[8 * 6 + 32 * 6 + 128 * 6] PROGMEM = {
     0xbb771c81, 0x3fd39b5a, 0xc197049e, 0xfe6deaa1, 0x40c7d2bd, 0xc0013bd3, 0xbdb00d71, 0x3ff4e5e0,
 };
 
-const int twidTabEven[4 * 6 + 16 * 6 + 64 * 6] PROGMEM = {
+const int twidTabEven[4 * 6 + 16 * 6 + 64 * 6] DPROGMEM = {
     0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x5a82799a, 0xd2bec333,
     0x539eba45, 0xe7821d59, 0x539eba45, 0xc4df2862, 0x40000000, 0xc0000000, 0x5a82799a, 0xd2bec333,
     0x00000000, 0xd2bec333, 0x00000000, 0xd2bec333, 0x539eba45, 0xc4df2862, 0xac6145bb, 0x187de2a7,


### PR DESCRIPTION
XIP cache is very slow and wasteful for some table indexing (low to no
cacheline reuse).  Move several AAC decode tables to RAM to allow
efficient random access.

Speeds up AAC SpeedTest by 17% at a cost of 12.5K RAM

Undo ESP8266 AAC huffman decoder hacks, no need to only store
hufftables at ints, we can access <32b ROM now.  Reduces flash
size by 14K