### PR TITLE
Allow setting raw buffer sizes, use in SD MP3 play

### DIFF
--- a/examples/SimpleMP3Shuffle/SimpleMP3Shuffle.ino
+++ b/examples/SimpleMP3Shuffle/SimpleMP3Shuffle.ino
@@ -27,7 +27,8 @@ const int _SCK = 6;
 
 // I2S out(OUTPUT, 0, 2);
 PWMAudio audio(0);
-BackgroundAudioMP3 BMP(audio);
+// We will make a larger buffer because SD cards can sometime take a long time to read
+BackgroundAudioMP3Class<RawDataBuffer<16 * 1024>> BMP(audio);
 
 // List of all MP3 files in the root directory
 std::vector<String> mp3list;

--- a/keywords.txt
+++ b/keywords.txt
@@ -9,6 +9,10 @@
 BackgroundAudioAAC	KEYWORD1
 BackgroundAudioMP3	KEYWORD1
 BackgroundAudioWAV	KEYWORD1
+BackgroundAudioAACClass	KEYWORD1
+BackgroundAudioMP3Class	KEYWORD1
+BackgroundAudioWAVClass	KEYWORD1
+RawDataBuffer	KEYWORD1
 ROMBackgroundAudioAAC	KEYWORD1
 ROMBackgroundAudioMP3	KEYWORD1
 ROMBackgroundAudioWAV	KEYWORD1

--- a/src/BackgroundAudioAAC.h
+++ b/src/BackgroundAudioAAC.h
@@ -217,5 +217,5 @@ private:
     uint32_t _dumps = 0;
 };
 
-using BackgroundAudioAAC = BackgroundAudioAACClass<RawDataBuffer>;
+using BackgroundAudioAAC = BackgroundAudioAACClass<RawDataBuffer<8 * 1024>>;
 using ROMBackgroundAudioAAC = BackgroundAudioAACClass<ROMDataBuffer>;

--- a/src/BackgroundAudioBuffers.h
+++ b/src/BackgroundAudioBuffers.h
@@ -23,6 +23,7 @@
 #include <Arduino.h>
 
 // Interrupt-safe, multicore-safe biftable buffer for libmad raw data.
+template <size_t bytes>
 class RawDataBuffer {
 public:
     RawDataBuffer() {
@@ -93,7 +94,7 @@ public:
     }
 
 private:
-    static const size_t count = 8 * 1024;
+    static const size_t count = bytes;
     uint8_t _buff[count];
     size_t _len;
     mutex_t _mtx;

--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -235,5 +235,5 @@ private:
     uint32_t _dumps = 0;
 };
 
-using BackgroundAudioMP3 = BackgroundAudioMP3Class<RawDataBuffer>;
+using BackgroundAudioMP3 = BackgroundAudioMP3Class<RawDataBuffer<8 * 1024>>;
 using ROMBackgroundAudioMP3 = BackgroundAudioMP3Class<ROMDataBuffer>;

--- a/src/BackgroundAudioWAV.h
+++ b/src/BackgroundAudioWAV.h
@@ -320,5 +320,5 @@ private:
     uint32_t _dumps = 0;
 };
 
+using BackgroundAudioWAV = BackgroundAudioWAVClass<RawDataBuffer<8 * 1024>>;
 using ROMBackgroundAudioWAV = BackgroundAudioWAVClass<ROMDataBuffer>;
-using BackgroundAudioWAV = BackgroundAudioWAVClass<RawDataBuffer>;


### PR DESCRIPTION
For some cases a larger source buffer is required.  Allow setting the size of the raw buffer and use it in the SD MP3 Player example.