### PR TITLE
Update section for RAM-resident AAC data

### DIFF
--- a/src/libhelix-aac/sbrtabs.c
+++ b/src/libhelix-aac/sbrtabs.c
@@ -46,7 +46,7 @@
 
 #include "sbr.h"
 
-#define DPROGMEM __attribute__(( section(".data") ))
+#define DPROGMEM __attribute__(( section(".time_critical.data") ))
 
 /*  k0Tab[sampRateIdx][k] = k0 = startMin + offset(bs_start_freq) for given sample rate (4.6.18.3.2.1)
     downsampled (single-rate) SBR not currently supported

--- a/src/libhelix-aac/trigtabs.c
+++ b/src/libhelix-aac/trigtabs.c
@@ -48,7 +48,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 
-#define DPROGMEM __attribute__(( section(".data") ))
+#define DPROGMEM __attribute__(( section(".time_critical.data") ))
 
 const int cos4sin4tabOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 


### PR DESCRIPTION
Remove the build warning about redefining data section attributes