### PR TITLE
Advance past WAV file FMT blocks

### DIFF
--- a/src/BackgroundAudioWAV.h
+++ b/src/BackgroundAudioWAV.h
@@ -246,6 +246,7 @@ private:
                         _accumShift++;
                         continue;
                     }
+                    _accumShift += 24;
                     _seenFMT = true;
                 } else if (_seenRIFF && _seenFMT && !_seenDATA && !memcmp(b, "data", 4)) {
                     if (avail < 8) {


### PR DESCRIPTION
Forgot to advance the pointer after decoding FMT blocks.  It still worked because the 2nd time it tried to process the same FMT block it would skip it as an unknown one.