### PR TITLE
Add ESP32 support

### DIFF
--- a/.github/workflows/pr-or-master-push.yml
+++ b/.github/workflows/pr-or-master-push.yml
@@ -81,3 +81,32 @@ jobs:
         rm -f *.elf
         find ~/Arduino/libraries/BackgroundAudio/examples -name \*.ino -print0 | xargs -0 -L1 bash ./tests/build-ci.sh rp2040:rp2040:rpipico2 rp2350
         size ./*.elf
+
+# Build all ESP32
+  build-all-esp32:
+    name: Build all examples on Arduino-ESP32 latest release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Arduino-CLI, ESP32 core, this library
+      run: |
+        wget https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_64bit.tar.gz
+        tar xf arduino-cli_nightly-latest_Linux_64bit.tar.gz
+        ./arduino-cli config init
+        ./arduino-cli config add board_manager.additional_urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
+        ./arduino-cli config set library.enable_unsafe_install true
+        ./arduino-cli core update-index
+        ./arduino-cli core install esp32:esp32
+        mkdir -p ~/Arduino/libraries
+        cp -a /home/runner/work/BackgroundAudio/BackgroundAudio ~/Arduino/libraries/.
+    - name: Build examples ESP32C6
+      run: |
+        mkdir esp32c6
+        rm -f *.elf
+        find ~/Arduino/libraries/BackgroundAudio/examples -name \*.ino -print0 | xargs -0 -L1 bash ./tests/build-ci-esp32.sh esp32:esp32:esp32c6 esp32c6
+        size ./*.elf

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# BackgroundAudio - Play MP3, AAC, and WAV on the Raspberry Pi Pico (RP2040) and Pico 2 (RP2350)
+# BackgroundAudio - Play MP3, AAC, and WAV on the Raspberry Pi Pico (RP2040), Pico 2 (RP2350), and ESP32
 
-BackgroundAudio is an Arduino library that lets sketches play MP3s, AACs, and WAVs on the Raspberry Pi Pico
-and Pico 2 with a very simple application level interface.  Data is written to the playback object when
+BackgroundAudio is an Arduino library that lets sketches play MP3s, AACs, and WAVs on the Raspberry Pi Pico,
+Pico 2, and ESP32 with a very simple application level interface.  Data is written to the playback object when
 available from the main application, and interrupts (IRQs) are used to generate data for I2S, PWMAudio,
 or Bluetooth A2DP in the background.  The application only needs to provide data faster than it is
 decompressed.  There is a source buffer that's managed by the playback routine, letting apps "fire and forget"
@@ -28,7 +28,8 @@ in both libraries, they're just used more efficiently here.)
 ## Compatibility
 
 BackgroundAudio today builds and runs under [Arduino-Pico](https://github.com/earlephilhower/arduino-pico),
-but ports to the ESP32 family would be welcomed.
+and [Arduino-ESP32](https://github.com/espressif/arduino-esp32).  It should be possible to port to any
+Arduino core which has I2S/audio packet callbacks to drive the processing.
 
 ## Adding BackgroundAudio to an Application
 
@@ -81,6 +82,21 @@ void loop() {
 
 }
 ````
+
+## ESP32 Implementation
+
+The ESP32 support requires the use of the built-in I2S wrapper library and does not use (and is not
+compatible) with the `I2S` library distributed with `Arduino-ESP32`.  Several additional features
+were required to port the background processing, and those are not available in the Arduino library.
+To instantiate the ESP32 I2S wrapper, copy the examples and use the following:
+
+````
+#include <ESP32I2SAudio.h>
+ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT
+````
+
+The `ESP32I2SAudio` object can be passed in to any of the BackgroundAudio constructors as it implements
+the `AudioOutputBase` class.
 
 ## Performance
 

--- a/examples/Mixer/Mixer.ino
+++ b/examples/Mixer/Mixer.ino
@@ -14,19 +14,31 @@
 #include <BackgroundAudioWAV.h>
 #include <BackgroundAudioAAC.h>
 #include <BackgroundAudioMixer.h>
-#include <PWMAudio.h>
 #include <__example_beepwav.h>
 #include <__example_pianoaac.h>
 
-PWMAudio pwm(0);
-BackgroundAudioMixer<512> mixer(pwm, 44100);
+#ifdef ESP32
+#include <ESP32I2SAudio.h>
+ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT
+#else
+#include <PWMAudio.h>
+PWMAudio audio(0);
+#endif
+
+BackgroundAudioMixer<512> mixer(audio, 44100);
 ROMBackgroundAudioWAV wav;
 ROMBackgroundAudioAAC aac;
 
 void setup() {
+  Serial.begin(115200);
+
   // Signal we've started
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, HIGH);
+
+#ifdef ESP32
+  Serial.printf("Press ENTER to beep!\n");
+#endif
 
   wav.setDevice(mixer.add());
   aac.setDevice(mixer.add());
@@ -40,14 +52,24 @@ void setup() {
 
 uint32_t last = 0;
 void loop() {
+#ifdef ESP32
+  if (Serial.available()) {
+#else
   if (BOOTSEL) {
+#endif
     wav.flush();  // Stop any existing output, reset for new file
     wav.write(beepwav, sizeof(beepwav));
     Serial.printf("BEEP!\r\n");
+#ifdef ESP32
+    while (Serial.available()) {
+      Serial.read();
+    }
+#else
     while (BOOTSEL) {
       /* wait for button release */
       delay(1);
     }
+#endif
   }
   if (millis() - last > 1000) {
     Serial.printf("Runtime: %lu\r\n", millis());

--- a/examples/NotSoSimpleMP3Shuffle/NotSoSimpleMP3Shuffle.ino
+++ b/examples/NotSoSimpleMP3Shuffle/NotSoSimpleMP3Shuffle.ino
@@ -23,8 +23,6 @@
 */
 
 #include <BackgroundAudio.h>
-#include <PWMAudio.h>
-#include <I2S.h>
 #include <SD.h>
 #include <vector>
 #include <string.h>
@@ -41,8 +39,15 @@ const int _MOSI = 7;  // AKA SPI TX
 const int _CS = 5;
 const int _SCK = 6;
 
-// I2S out(OUTPUT, 0, 2);
+#ifdef ESP32
+#include <ESP32I2SAudio.h>
+ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT
+#else
+#include <PWMAudio.h>
+#include <I2S.h>
+// I2S audio(OUTPUT, 0, 2);
 PWMAudio audio(0);
+#endif
 // We will make a larger buffer because SD cards can sometime take a long time to read
 BackgroundAudioMP3Class<RawDataBuffer<16 * 1024>> BMP(audio);
 
@@ -88,11 +93,21 @@ void scanDirectory(const char *dirname) {
 }
 
 void setup() {
+  Serial.begin(115200);
+
   // Ensure a different random sequence every time we start up
+#ifdef ESP32
+  srand(ESP.getCycleCount());
+#else
   srand(rp2040.hwrand32());
+#endif
 
   // Initialize the SD card
   bool sdInitialized = false;
+#ifdef ESP32
+  SPI.begin(_SCK, _MISO, _MOSI, _CS);
+  sdInitialized = SD.begin(_CS);
+#else
   if (_MISO == 0 || _MISO == 4 || _MISO == 16) {
     SPI.setRX(_MISO);
     SPI.setTX(_MOSI);
@@ -109,11 +124,17 @@ void setup() {
       delay(1);
     }
   }
+#endif
+
   if (!sdInitialized) {
     Serial.println("initialization failed!");
     while (1) {
       delay(1000);
+#ifdef ESP32
+      ESP.restart();
+#else
       rp2040.reboot();
+#endif
     }
   }
 
@@ -125,6 +146,14 @@ void setup() {
 
 void loop() {
   // When BOOTSEL held, skip to another song
+#ifdef ESP32
+  if (Serial.available()) {
+    f.close();  // Choose another
+    while (Serial.available()) {
+      Serial.read();
+    }
+  }
+#else
   if (BOOTSEL) {
     f.close();  // Choose another
     // wait for release
@@ -132,6 +161,7 @@ void loop() {
       delay(1);
     }
   }
+#endif
 
   // Choose a song from the list if there's no open file
   if (!f) {

--- a/examples/PlayAACROM/PlayAACROM.ino
+++ b/examples/PlayAACROM/PlayAACROM.ino
@@ -11,15 +11,21 @@
 // Intended as a simple demonstration of BackgroundAudio usage.
 
 #include <BackgroundAudioAAC.h>
-#include <I2S.h>
 #include <__example_pianoaac.h>
 
+#ifdef ESP32
+#include <ESP32I2SAudio.h>
+ESP32I2SAudio i2s(4, 5, 6); // BCLK, LRCLK, DOUT
+#else
+#include <I2S.h>
 I2S i2s(OUTPUT, 0, 2);
+#endif
 ROMBackgroundAudioAAC BMP(i2s);
 
 bool stopped = false;
 
 void setup() {
+  Serial.begin(115200);
   delay(5000);
 
   // Signal we've started

--- a/examples/SpeedTest/SpeedTest.ino
+++ b/examples/SpeedTest/SpeedTest.ino
@@ -27,7 +27,13 @@ uint32_t aacframes = 0;
 uint32_t aacheframes = 0;
 uint32_t mp3frames = 0;
 
+#ifdef ESP32
+#define rp2040 ESP
+#define getCycleCount64 getCycleCount
+#endif
+
 void setup() {
+  Serial.begin(115200);
   _hAACDecoder = AACInitDecoder();
   int idx = 0;
   uint64_t now = rp2040.getCycleCount64();

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "name": "BackgroundAudio",
     "description": "Plays MP3, AAC, and WAV via an IRQ based mechanism to allow multitasking while playing",
-    "keywords": "Pico, RP2040, Pico 2, RP2350, MP3, AAC, WAV, I2S, PWM, Webradio",
+    "keywords": "Pico, RP2040, Pico 2, RP2350, MP3, AAC, WAV, I2S, PWM, Webradio, ESP32",
     "authors": [
         {
             "name": "Earle F. Philhower, III",

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Plays MP3, AAC, and WAV via an IRQ based mechanism to allow "multitaski
 paragraph=Uses interrupts to allow a sketch to run while MP3, AAC, or WAV decoding goes on behind the scenes. Decodes in natural frames to optimize CPU usage. Allows for handling the UI of a sketch without stopping or jitter on playback.
 category=Communication
 url=http://github.com/earlephilhower/arduino-pico
-architectures=rp2040
+architectures=rp2040,esp32
 dot_a_linkage=true

--- a/src/BackgroundAudioAAC.h
+++ b/src/BackgroundAudioAAC.h
@@ -21,7 +21,7 @@
 
 #pragma once
 #include <Arduino.h>
-#include <AudioOutputBase.h>
+#include "WrappedAudioOutputBase.h"
 #include "BackgroundAudioGain.h"
 #include "BackgroundAudioBuffers.h"
 #include "libhelix-aac/aacdec.h"

--- a/src/BackgroundAudioBuffers.h
+++ b/src/BackgroundAudioBuffers.h
@@ -91,7 +91,7 @@ public:
 #else
         mutex_exit(&_mtx);
         interrupts();
-#endif        
+#endif
         return toWrite;
     }
 

--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -21,7 +21,7 @@
 
 #pragma once
 #include <Arduino.h>
-#include <AudioOutputBase.h>
+#include "WrappedAudioOutputBase.h"
 #include "BackgroundAudioGain.h"
 #include "BackgroundAudioBuffers.h"
 #include "libmad/config.h"

--- a/src/BackgroundAudioMixer.h
+++ b/src/BackgroundAudioMixer.h
@@ -21,7 +21,7 @@
 
 #pragma once
 #include <Arduino.h>
-#include <AudioOutputBase.h>
+#include "WrappedAudioOutputBase.h"
 #include <vector>
 
 // The mixer input will buffer output from one audio source and resample to
@@ -188,8 +188,7 @@ public:
     }
 
 private:
-    // Can't use std::list because we need to put in RAM for IRQ use, so roll our own
-    void __not_in_flash_func(_addToList)(AudioBuffer **list, AudioBuffer *element) {
+    void _addToList(AudioBuffer **list, AudioBuffer *element) {
         noInterrupts();
         // Find end of list, if any
         while ((*list) && ((*list)->next != nullptr)) {
@@ -204,7 +203,7 @@ private:
         interrupts();
     }
 
-    AudioBuffer *__not_in_flash_func(_takeFromList)(AudioBuffer **list) {
+    AudioBuffer *_takeFromList(AudioBuffer **list) {
         noInterrupts();
         auto ret = *list;
         if (ret) {

--- a/src/BackgroundAudioWAV.h
+++ b/src/BackgroundAudioWAV.h
@@ -21,7 +21,7 @@
 
 #pragma once
 #include <Arduino.h>
-#include <AudioOutputBase.h>
+#include "WrappedAudioOutputBase.h"
 #include "BackgroundAudioBuffers.h"
 #include "BackgroundAudioGain.h"
 

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -117,11 +117,11 @@ public:
         i2s_channel_init_std_mode(_tx_handle, &std_cfg);
 
         // Prefill silence and calculate how bug we really have
-        int16_t a[2] = {0,0};
+        int16_t a[2] = {0, 0};
         size_t written = 0;
         do {
-          i2s_channel_preload_data(_tx_handle, (void*)a, sizeof(a), &written);
-          _totalAvailable += written;
+            i2s_channel_preload_data(_tx_handle, (void*)a, sizeof(a), &written);
+            _totalAvailable += written;
         } while (written);
 
         // The IRQ callbacks which will just trigger the playback task
@@ -138,12 +138,12 @@ public:
     }
 
     static bool _onSent(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
-      return ((ESP32I2SAudio *)user_ctx)->_onSentCB(handle, event);
+        return ((ESP32I2SAudio *)user_ctx)->_onSentCB(handle, event);
     }
 
 
     static bool _onSentUnder(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
-      return ((ESP32I2SAudio *)user_ctx)->_onSentCB(handle, event, true);
+        return ((ESP32I2SAudio *)user_ctx)->_onSentCB(handle, event, true);
     }
 
     static void _taskShim(void *pvParameters) {
@@ -162,7 +162,7 @@ public:
             }
             _available += size;
             if (_available > _totalAvailable) {
-              _available = _totalAvailable;
+                _available = _totalAvailable;
             }
             if (_cb) {
                 _cb(_cbData);
@@ -203,18 +203,18 @@ public:
 
     // From Print
     size_t write(const uint8_t *buffer, size_t size) override {
-      size_t written = 0;
-      i2s_channel_write(_tx_handle, buffer, size, &written, 0);
-      noInterrupts(); // TODO - Freertos task protection instead?
-      if (written != size) {
-        _available = 0;
-      } else if (_available >= written) {
-        _available -= written;
-      } else {
-        _available = 0;
-      }
-      interrupts();
-      return  written;
+        size_t written = 0;
+        i2s_channel_write(_tx_handle, buffer, size, &written, 0);
+        noInterrupts(); // TODO - Freertos task protection instead?
+        if (written != size) {
+            _available = 0;
+        } else if (_available >= written) {
+            _available -= written;
+        } else {
+            _available = 0;
+        }
+        interrupts();
+        return  written;
     }
 
     size_t write(uint8_t d) override {

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -1,0 +1,248 @@
+/*
+    BackgroundAudio
+    Plays an audio file using IRQ driven decompression.  Main loop() writes
+    data to the buffer but isn't blocked while playing
+
+    Copyright (c) 2025 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <driver/i2s_std.h>
+#include "WrappedAudioOutputBase.h"
+
+class ESP32I2SAudio : public AudioOutputBase {
+public:
+    ESP32I2SAudio(int8_t bclk = 0, int8_t ws = 1, int8_t dout = 2, int8_t mclk = -1) {
+        _bclk = bclk;
+        _ws = ws;
+        _dout = dout;
+        _mclk = mclk;
+        _running = false;
+        _sampleRate = 44100;
+        _buffers = 5;
+        _bufferWords = 512;
+        _silenceSample = 0;
+        _cb = nullptr;
+    }
+
+    virtual ~ESP32I2SAudio() {
+    }
+
+    void setPins(int8_t bclk, int8_t ws, int8_t dout, int8_t mclk = -1) {
+        _bclk = bclk;
+        _ws = ws;
+        _dout = dout;
+        _mclk = mclk;
+    }
+
+    void setInverted(bool bclk, bool ws, bool mclk = false) {
+        _bclkInv = bclk;
+        _wsInv = ws;
+        _mclkInv = mclk;
+    }
+
+    bool setBuffers(size_t buffers, size_t bufferWords, int32_t silenceSample = 0) override {
+        if (!_running) {
+            _buffers = buffers;
+            _bufferWords = bufferWords;
+            _silenceSample = silenceSample;
+        }
+        return !_running;
+    }
+
+    bool setBitsPerSample(int bps) override {
+        if (!_running && bps == 16)  {
+            return true;
+        }
+        return false;
+    }
+
+    bool setFrequency(int freq) override {
+        if (_running && (_sampleRate != freq)) {
+            i2s_std_clk_config_t clk_cfg;
+            clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG((uint32_t)freq);
+            i2s_channel_disable(_tx_handle);
+            i2s_channel_reconfig_std_clock(_tx_handle, &clk_cfg);
+            i2s_channel_enable(_tx_handle);
+        }
+        _sampleRate = freq;
+        return true;
+    }
+
+    bool setStereo(bool stereo = true) override {
+        return stereo;
+    }
+
+    bool begin() override {
+        if (_running) {
+            return false;
+        }
+
+        // Make a new channel of the requested buffers (which may be ignored by the IDF!)
+        i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, I2S_ROLE_MASTER);
+        chan_cfg.dma_desc_num = _buffers;
+        chan_cfg.dma_frame_num = _bufferWords * 4;
+        i2s_new_channel(&chan_cfg, &_tx_handle, nullptr);
+
+        i2s_std_config_t std_cfg = {
+            .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(_sampleRate),
+            .slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
+            .gpio_cfg = {
+                .mclk = _mclk < 0 ? I2S_GPIO_UNUSED : (gpio_num_t)_mclk,
+                .bclk = (gpio_num_t)_bclk,
+                .ws = (gpio_num_t)_ws,
+                .dout = (gpio_num_t)_dout,
+                .din = I2S_GPIO_UNUSED,
+                .invert_flags = {
+                    .mclk_inv = _mclkInv,
+                    .bclk_inv = _bclkInv,
+                    .ws_inv = _wsInv,
+                },
+            },
+        };
+        i2s_channel_init_std_mode(_tx_handle, &std_cfg);
+
+        // Prefill silence and calculate how bug we really have
+        int16_t a[2] = {0,0};
+        size_t written = 0;
+        do {
+          i2s_channel_preload_data(_tx_handle, (void*)a, sizeof(a), &written);
+          _totalAvailable += written;
+        } while (written);
+
+        // The IRQ callbacks which will just trigger the playback task
+        i2s_event_callbacks_t _cbs = {
+            .on_recv = nullptr,
+            .on_recv_q_ovf = nullptr,
+            .on_sent = _onSent,
+            .on_send_q_ovf = _onSentUnder
+        };
+        i2s_channel_register_event_callback(_tx_handle, &_cbs, (void *)this);
+        xTaskCreate(_taskShim, "BackgroundAudioI2S", 4096, (void*)this, 2, &_taskHandle);
+        _running = ESP_OK == i2s_channel_enable(_tx_handle);
+        return _running;
+    }
+
+    static bool _onSent(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
+      return ((ESP32I2SAudio *)user_ctx)->_onSentCB(handle, event);
+    }
+
+
+    static bool _onSentUnder(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
+      return ((ESP32I2SAudio *)user_ctx)->_onSentCB(handle, event, true);
+    }
+
+    static void _taskShim(void *pvParameters) {
+        ((ESP32I2SAudio *)pvParameters)->_backgroundTask();
+    }
+
+    void _backgroundTask() {
+        while (true) {
+            uint32_t ulNotifiedValue;
+            xTaskNotifyWait(0, ULONG_MAX, &ulNotifiedValue, portMAX_DELAY);
+            _frames++;
+            int32_t size = (int32_t)ulNotifiedValue;
+            if (size < 0) {
+                _underflows++;
+                size = -size;
+            }
+            _available += size;
+            if (_available > _totalAvailable) {
+              _available = _totalAvailable;
+            }
+            if (_cb) {
+                _cb(_cbData);
+            }
+        }
+    }
+
+    uint32_t _irqs = 0;
+    uint32_t _frames = 0;
+    uint32_t _underflows = 0;
+
+    bool _onSentCB(i2s_chan_handle_t handle, i2s_event_data_t *event, bool underflow = false) {
+        BaseType_t xHigherPriorityTaskWoken;
+        xHigherPriorityTaskWoken = pdFALSE;
+        if (_taskHandle) {
+            _irqs++;
+            xTaskNotifyFromISR(_taskHandle, event->size * (underflow ? -1 : 1), eSetValueWithOverwrite, &xHigherPriorityTaskWoken);
+        }
+        return (bool)xHigherPriorityTaskWoken;
+    }
+
+
+    bool end() override {
+        // TODO
+        return false;
+    }
+
+    bool getUnderflow() override {
+        return false; // TODO
+    }
+
+    void onTransmit(void(*cb)(void *), void *cbData) override {
+        noInterrupts();
+        _cb = cb;
+        _cbData = cbData;
+        interrupts();
+    }
+
+    // From Print
+    size_t write(const uint8_t *buffer, size_t size) override {
+      size_t written = 0;
+      i2s_channel_write(_tx_handle, buffer, size, &written, 0);
+      noInterrupts(); // TODO - Freertos task protection instead?
+      if (written != size) {
+        _available = 0;
+      } else if (_available >= written) {
+        _available -= written;
+      } else {
+        _available = 0;
+      }
+      interrupts();
+      return  written;
+    }
+
+    size_t write(uint8_t d) override {
+        return 0; // No bytes!
+    }
+
+    int availableForWrite() override {
+        return _available; // It's our best guess for now
+    }
+
+private:
+    bool _running;
+    int8_t _bclk = 0;
+    int8_t _ws = 1;
+    int8_t _dout = 2;
+    int8_t _mclk = -1;
+    bool _bclkInv = false;
+    bool _wsInv = false;
+    bool _mclkInv = false;
+    size_t _sampleRate;
+    size_t _buffers;
+    size_t _bufferWords;
+    uint32_t _silenceSample;
+    TaskHandle_t _taskHandle = 0;
+    void (*_cb)(void *);
+    void *_cbData;
+    // I2S IDF object and info
+    i2s_chan_handle_t _tx_handle;
+    size_t _totalAvailable = 0;
+    size_t _available = 0;
+};

--- a/src/WrappedAudioOutputBase.h
+++ b/src/WrappedAudioOutputBase.h
@@ -1,0 +1,50 @@
+/*
+    BackgroundAudio
+    Plays an audio file using IRQ driven decompression.  Main loop() writes
+    data to the buffer but isn't blocked while playing
+
+    Copyright (c) 2025 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef ESP32
+
+// Abstract class for audio output devices to allow easy swapping between output devices
+
+#include <Print.h>
+
+class AudioOutputBase : public Print {
+public:
+    virtual ~AudioOutputBase() { }
+    virtual bool setBuffers(size_t buffers, size_t bufferWords, int32_t silenceSample = 0) = 0;
+    virtual bool setBitsPerSample(int bps) = 0;
+    virtual bool setFrequency(int freq) = 0;
+    virtual bool setStereo(bool stereo = true) = 0;
+    virtual bool begin() = 0;
+    virtual bool end() = 0;
+    virtual bool getUnderflow() = 0;
+    virtual void onTransmit(void(*)(void *), void *) = 0;
+    // From Print
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    virtual int availableForWrite() = 0;
+};
+
+#else
+
+#include <AudioOutputBase.h>
+
+#endif

--- a/src/libhelix-aac/sbrtabs.c
+++ b/src/libhelix-aac/sbrtabs.c
@@ -46,7 +46,11 @@
 
 #include "sbr.h"
 
+#if defined(PICO_RP2040) || defined(PICO_RP2350)
 #define DPROGMEM __attribute__(( section(".time_critical.data") ))
+#else
+#define DPROGMEM PROGMEM
+#endif
 
 /*  k0Tab[sampRateIdx][k] = k0 = startMin + offset(bs_start_freq) for given sample rate (4.6.18.3.2.1)
     downsampled (single-rate) SBR not currently supported

--- a/src/libhelix-aac/trigtabs.c
+++ b/src/libhelix-aac/trigtabs.c
@@ -48,7 +48,11 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 
+#if defined(PICO_RP2040) || defined(PICO_RP2350)
 #define DPROGMEM __attribute__(( section(".time_critical.data") ))
+#else
+#define DPROGMEM PROGMEM
+#endif
 
 const int cos4sin4tabOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 

--- a/tests/build-ci-esp32.sh
+++ b/tests/build-ci-esp32.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Called by CI to compile and dump an example
+# built-ci.sh <FQBN> <output-directory> <full-path-to-ino>
+
+# Ensure any failure == exit with error
+set -e
+set -o pipefail
+
+echo "::group::Compiling $(basename $3) for $1 into $2"
+./arduino-cli compile -b "$1" -v --warnings all --build-path "$2" "$3" || exit 255
+mv -f "$2"/*.elf .
+echo "::endgroup::"


### PR DESCRIPTION
Build an I2S wrapper class with the features we need to support the background audio processing (namely, callbacks as I2S goes out).

Do actual I2S processing in a separate FreeRTOS task since we can't actually do any I2S reads or writes on the I2S IRQ callback.

Update the examples to work with ESP32 Arduino