### PR TITLE
Expand ESP32 MP3 buffer for Web, add backoff

### DIFF
--- a/examples/BeepWAV/BeepWAV.ino
+++ b/examples/BeepWAV/BeepWAV.ino
@@ -16,7 +16,7 @@
 
 #ifdef ESP32
 #include <ESP32I2SAudio.h>
-ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT
+ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT (,MCLK)
 #else
 #include <PWMAudio.h>
 PWMAudio audio(0);

--- a/examples/Mixer/Mixer.ino
+++ b/examples/Mixer/Mixer.ino
@@ -19,7 +19,7 @@
 
 #ifdef ESP32
 #include <ESP32I2SAudio.h>
-ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT
+ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT (,MCLK)
 #else
 #include <PWMAudio.h>
 PWMAudio audio(0);

--- a/examples/NotSoSimpleMP3Shuffle/NotSoSimpleMP3Shuffle.ino
+++ b/examples/NotSoSimpleMP3Shuffle/NotSoSimpleMP3Shuffle.ino
@@ -41,7 +41,7 @@ const int _SCK = 6;
 
 #ifdef ESP32
 #include <ESP32I2SAudio.h>
-ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT
+ESP32I2SAudio audio(4, 5, 6); // BCLK, LRCLK, DOUT (,MCLK)
 #else
 #include <PWMAudio.h>
 #include <I2S.h>

--- a/examples/PlayAACROM/PlayAACROM.ino
+++ b/examples/PlayAACROM/PlayAACROM.ino
@@ -15,7 +15,7 @@
 
 #ifdef ESP32
 #include <ESP32I2SAudio.h>
-ESP32I2SAudio i2s(4, 5, 6); // BCLK, LRCLK, DOUT
+ESP32I2SAudio i2s(4, 5, 6); // BCLK, LRCLK, DOUT (,MCLK)
 #else
 #include <I2S.h>
 I2S i2s(OUTPUT, 0, 2);


### PR DESCRIPTION
In the web streaming example, when we fall too low pause the MP3 playback to allow for the buffer to refill and avoid repeated stuttering.

Increase the buffer on the ESP32, there seems to be massively much greater jitter on the ESP vs. the Pico.