### PR TITLE
Speech: Fix final frame clipping, flushing

### DIFF
--- a/examples/WebradioMP3PlusWebUI/WebradioMP3PlusWebUI.ino
+++ b/examples/WebradioMP3PlusWebUI/WebradioMP3PlusWebUI.ino
@@ -11,8 +11,8 @@
 #include <WebServer.h>
 
 #ifndef STASSID
-#define STASSID "NOBABIES"
-#define STAPSK "ElephantsAreGreat"
+#define STASSID "ssid"
+#define STAPSK "password"
 #endif
 
 const char *ssid = STASSID;

--- a/src/libespeak-ng/espeak-ng/speak_lib.h
+++ b/src/libespeak-ng/espeak-ng/speak_lib.h
@@ -710,8 +710,17 @@ ESPEAK_API const char *espeak_Info(const char **path_data);
 #ifdef __cplusplus
 extern "C"
 #endif
-ESPEAK_API int SynthesizeOneStep(unsigned int unique_identifier, const void *text, int flags);
-/* Generates up to one period worth of samples, returns 0 on success or !0 on end of speech or error */
+ESPEAK_API int espeak_SynthesizeOneStep(short **out);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+ESPEAK_API void espeak_AbortSynthesis();
+
+#ifdef __cplusplus
+extern "C"
+#endif
+ESPEAK_API int espeak_SynthesisGenerateNext();
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Rewrite the ESpeak added API to be non-callback and adjust generation to not drop the final sample buffer.  Speech::flush() now stops generation immediately and lets a new phrase begin without pause.