### PR TITLE
Replace 'mp3' word with 'aac'

### DIFF
--- a/examples/PlayAACROM/PlayAACROM.ino
+++ b/examples/PlayAACROM/PlayAACROM.ino
@@ -4,7 +4,7 @@
 // Plays a small AAC file from ROM asynchronously with a single call.
 // Hook up an I2S DAC bclk=0; lrclk=1, data=2
 //
-// Generate the ROM file by using "xxd -i file.mp3 file.h" and then
+// Generate the ROM file by using "xxd -i file.aac file.h" and then
 // editing the output header to make the array "const" so it stays
 // only in flash.
 //


### PR DESCRIPTION
First things first -> Thanks for sharing this awesome library!

It seems `file.mp3` won't work here. The input file needs to be an `.aac` file perhaps?

PS: I have the AAC example working pretty well with the CJMCU-4344 DAC module. It should also work with ESHINE CJC4334 DAC which is very reasonably priced (on LCSC). If there is interest in this work, I can open a PR quickly ;)