### PR TITLE
fix repo url in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Earle F. Philhower, III <earlephilhower@yahoo.com>
 sentence=Plays MP3, AAC, and WAV via an IRQ based mechanism to allow "multitasking" while playing
 paragraph=Uses interrupts to allow a sketch to run while MP3, AAC, or WAV decoding goes on behind the scenes. Decodes in natural frames to optimize CPU usage. Allows for handling the UI of a sketch without stopping or jitter on playback.
 category=Communication
-url=http://github.com/earlephilhower/arduino-pico
+url=https://github.com/earlephilhower/BackgroundAudio
 architectures=rp2040,esp32
 dot_a_linkage=true


### PR DESCRIPTION
I notice this points to the wrong repository when clicking "More info" in the Arduino IDE