### PR TITLE
Fix Audio issues with IDF 5.5 on ESP32S3

### DIFF
--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -351,7 +351,7 @@ private:
                     _out->setFrequency(_synth.pcm.samplerate);
                 }
             }
-            
+
             // Try to push the whole frame, but don't spin forever if we can't
             uint8_t* p = reinterpret_cast<uint8_t*>(_synth.pcm.samplesX);
             size_t remaining = _synth.pcm.length * 4;

--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -351,7 +351,15 @@ private:
                     _out->setFrequency(_synth.pcm.samplerate);
                 }
             }
-            _out->write((uint8_t *)_synth.pcm.samplesX, _synth.pcm.length * 4);
+            
+            // Try to push the whole frame, but don't spin forever if we can't
+            uint8_t* p = reinterpret_cast<uint8_t*>(_synth.pcm.samplesX);
+            size_t remaining = _synth.pcm.length * 4;
+            while (remaining) {
+                size_t n = _out->write(p, remaining);
+                p += n;
+                remaining -= n;
+            }
         }
     }
 

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -262,8 +262,7 @@ public:
         do {
             uint64_t sum = (uint64_t)cur + add;
             uint32_t capped = (sum > _totalAvailable) ? (uint32_t)_totalAvailable : (uint32_t)sum;
-            if (_available.compare_exchange_weak(cur, capped,
-                   std::memory_order_release, std::memory_order_relaxed)) {
+            if (_available.compare_exchange_weak(cur, capped, std::memory_order_release, std::memory_order_relaxed)) {
                 return;
             }
             // cur reloaded on failure
@@ -274,8 +273,7 @@ public:
         uint32_t cur = _available.load(std::memory_order_relaxed);
         do {
             uint32_t next = (cur > sub) ? (cur - sub) : 0u;
-            if (_available.compare_exchange_weak(cur, next,
-                    std::memory_order_release, std::memory_order_relaxed)) {
+            if (_available.compare_exchange_weak(cur, next, std::memory_order_release, std::memory_order_relaxed)) {
                 return;
             }
         } while (true);
@@ -401,7 +399,7 @@ public:
     int availableForWrite() override {
         i2s_chan_info_t _info;
         i2s_channel_get_info(_tx_handle, &_info);
-        return (int)_available.load(std::memory_order_acquire)/4;
+        return (int)_available.load(std::memory_order_acquire) / 4;
     }
 
 private:


### PR DESCRIPTION
Not sure this ever worked with different IDF versions. However in IDF5.5. there was a noticeable stutter in the sound. On Close investigation I found it related to ESPIDF only allowing 1023 words of buffer to be transmitted with DMA, which lead to writing to the stream not writing the full sample in pump. 
I updated the MP3 pump function to handle frame misalignment as well as made ESP32I2S a bit more robust. 


BackgroundAudioMP3:
- Handle frame mismatch in BackgroundAudioMP3.h between decoder and out…put source.

Update ESP32I2SAudio to
- allocate buffer to DMA maximum of 1023 words
- instead of estimating _totalAvailable, query info
- remove underflow logic, which actually measured overflow events, which shouldn't happen
- replace disableing of interrupts with atomic
- report frames in availableForWrite, which keeps all other audio sources stable - not sure that's correct availableForWrite in the audio source could also remain bytes, but then the comparisson in pump needs to either multiply by 4)