### PR TITLE
Fix ignored-qualifiers in BackgroundAudioMixer

### DIFF
--- a/src/BackgroundAudioMixer.h
+++ b/src/BackgroundAudioMixer.h
@@ -230,7 +230,7 @@ public:
         }
         size_t words = size / sizeof(uint32_t);
         while (words) {
-            AudioBuffer **volatile p = (AudioBuffer * *volatile)&_empty;
+            AudioBuffer **volatile p = &_empty;
             if (!*p) {
                 break;
             }


### PR DESCRIPTION
Arduino-Pico 4.7.0 removed the no-ignored-qualifiers, surfacing a no-op cast that needs to be removed.