### PR TITLE
Fix underflow logic.

### DIFF
--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -267,7 +267,7 @@ public:
                 _underflowed.store(true, std::memory_order_release);
                 _underflows.fetch_add(1, std::memory_order_relaxed);
             }
-            
+
             if (_available.compare_exchange_weak(cur, capped, std::memory_order_release, std::memory_order_relaxed)) {
                 return;
             }

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -261,7 +261,13 @@ public:
         uint32_t cur = _available.load(std::memory_order_relaxed);
         do {
             uint64_t sum = (uint64_t)cur + add;
-            uint32_t capped = (sum > _totalAvailable) ? (uint32_t)_totalAvailable : (uint32_t)sum;
+            uint32_t capped = sum;
+            if (sum > _totalAvailable) {
+                capped = (uint32_t) _totalAvailable;  // Cap to the total available
+                _underflowed.store(true, std::memory_order_release);
+                _underflows.fetch_add(1, std::memory_order_relaxed);
+            }
+            
             if (_available.compare_exchange_weak(cur, capped, std::memory_order_release, std::memory_order_relaxed)) {
                 return;
             }
@@ -304,7 +310,7 @@ public:
               @return Number of frames of underflow data have occurred
     */
     uint32_t underflows() {
-        return _underflows;
+        return _underflows.load(std::memory_order_acquire);
     }
 
     /**
@@ -312,14 +318,11 @@ public:
 
         @return True if a task was woken up (FreeRTOS xHigherPriorityTaskWoken)
     */
-    IRAM_ATTR bool _onSentCB(i2s_chan_handle_t handle, i2s_event_data_t *event, bool underflow = false) {
+    IRAM_ATTR bool _onSentCB(i2s_chan_handle_t handle, i2s_event_data_t *event) {
         BaseType_t xHigherPriorityTaskWoken;
         xHigherPriorityTaskWoken = pdFALSE;
         if (_taskHandle) {
             _irqs++;
-            if (underflow) {
-                _underflowed = true;
-            }
             xTaskNotifyFromISR(_taskHandle, event->size, eSetValueWithoutOverwrite, &xHigherPriorityTaskWoken);
         }
         if (xHigherPriorityTaskWoken) {
@@ -425,5 +428,5 @@ private:
     std::atomic<uint32_t> _available{0};
     uint32_t _irqs = 0; // Number of I2S IRQs received
     uint32_t _frames = 0; // Number of DMA buffers sent
-    uint32_t _underflows = 0; // Number of underflowed DMA buffers
+    std::atomic<uint32_t> _underflows{0}; // Number of underflowed DMA buffers
 };


### PR DESCRIPTION
During an underflow situation the I2S component will repeat the last buffer until new data is received. That means we will receive an on_sent event without a corresponding write. As a result available will be larger than total available

This was tested with this main:

```
// Board: ESP32-S3 (Arduino core 3.x)
// Lib: BackgroundAudio (Earle Philhower) — we only use ESP32I2SAudio here
// Wiring: BCLK=5, LRCLK/WS=4, DIN=6 (to MAX98357 or similar)

#include <Arduino.h>
#include <math.h>

#include <BackgroundAudio.h>
#include <ESP32I2SAudio.h>

#define PIN_LRC   4   // LRCLK/WS
#define PIN_BCLK  5   // BCLK
#define PIN_DIN   6   // to MAX98357 DIN

// I2S device (BCLK, LRCLK, DOUT)
ESP32I2SAudio i2s(PIN_BCLK, PIN_LRC, PIN_DIN);

// Config
static const uint32_t SAMPLE_RATE = 44100;   // pick any reasonable rate
static const float    AMP = 0.5f;            // 0.5 * full-scale to be safe
static const int      N = 1023;              // EXACTLY 1023 samples (per channel)

// Interleaved stereo buffer: [L0, R0, L1, R1, ...]
int16_t pcm[2 * N];

void fillHalfSine()
{
  // Half-sine from 0 to π inclusive, 1023 points:
  // n = 0..1022, theta = π * n / 1022
  for (int n = 0; n < N; ++n) {
    float theta = (float)M_PI * (float)n / (float)(N - 1);  // 0..π inclusive
    float s = sinf(theta);
    int16_t v = (int16_t)lrintf(s * AMP * 32767.0f);
    pcm[2*n + 0] = v;  // L
    pcm[2*n + 1] = v;  // R
  }
}

void setup()
{
  Serial.begin(115200);
  delay(2000);
  Serial.println("\nESP32I2S starvation test: 1023-sample half-sine, then no more data.");

  fillHalfSine();
  i2s.setFrequency(SAMPLE_RATE);  // Set the sample rate

  // Start I2S output. (Defaults: 16-bit stereo. Some versions accept bits param.)
  if (!i2s.begin()) {
    Serial.println("i2s.begin() failed");
    while (true) delay(1000);
  }

  // Write the buffer ONCE, then stop feeding to starve the DMA later.
  size_t total = sizeof(pcm);
  size_t off = 0;

  while (off < total) {
    // Write as many bytes as the driver will take; if zero, yield and retry.
    size_t wrote = i2s.write(reinterpret_cast<const uint8_t*>(pcm) + off, total - off);
    if (wrote == 0) {
      delay(1);
      continue;
    }
    off += wrote;
  }

  Serial.println("Wrote 1023 stereo frames. Now starving I2S (no further writes).");
}

void loop()
{
  // Intentionally do nothing: no more writes => I2S will underrun/starve.
  // You can watch what your codec/amp does in this state.
  delay(10);
  Serial.println(i2s.underflows());
}
```