### PR TITLE
ESP32I2S write should try multiple DMA buffers, obey size constraints, allow for small timeout

### DIFF
--- a/src/BackgroundAudioAAC.h
+++ b/src/BackgroundAudioAAC.h
@@ -332,7 +332,7 @@ private:
                     _out->setFrequency(_sampleRate);
                 }
             }
-            _out->write((uint8_t *)_outSample, _outSamples * 2 * sizeof(int16_t));
+            assert(_out->write((uint8_t *)_outSample, _outSamples * 2 * sizeof(int16_t)) == _outSamples * 2 * sizeof(int16_t));
         }
     }
 

--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -351,15 +351,7 @@ private:
                     _out->setFrequency(_synth.pcm.samplerate);
                 }
             }
-
-            // Try to push the whole frame, but don't spin forever if we can't
-            uint8_t* p = reinterpret_cast<uint8_t*>(_synth.pcm.samplesX);
-            size_t remaining = _synth.pcm.length * 4;
-            while (remaining) {
-                size_t n = _out->write(p, remaining);
-                p += n;
-                remaining -= n;
-            }
+            assert(_out->write((uint8_t *)_synth.pcm.samplesX, _synth.pcm.length * 4) == _synth.pcm.length * 4);
         }
     }
 

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -109,6 +109,13 @@ public:
         if (!_running) {
             _buffers = buffers;
             _bufferWords = bufferWords;
+            // We need DMA buffers of 1023 4-byte samples or less. Adjust behind the scenes.
+            // The upper level code will get 2x or 4x the IRQs, but availableForWrite() should
+            // still report the proper space and let it do nothing for the extra IRQs.
+            while (_bufferWords > 1023) {
+                _buffers *= 2;
+                _bufferWords /= 2;
+            }
             _silenceSample = silenceSample;
         }
         return !_running;
@@ -177,7 +184,7 @@ public:
         i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, I2S_ROLE_MASTER);
         chan_cfg.dma_desc_num = _buffers;
         chan_cfg.dma_frame_num = _bufferWords;
-        i2s_new_channel(&chan_cfg, &_tx_handle, nullptr);
+        assert(ESP_OK == i2s_new_channel(&chan_cfg, &_tx_handle, nullptr));
 
         i2s_std_config_t std_cfg = {
             .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(_sampleRate),
@@ -195,10 +202,12 @@ public:
                 },
             },
         };
-        i2s_channel_init_std_mode(_tx_handle, &std_cfg);
+        assert(ESP_OK == i2s_channel_init_std_mode(_tx_handle, &std_cfg));
 
         i2s_chan_info_t _info;
         i2s_channel_get_info(_tx_handle, &_info);
+        // If the IDF has changed our buffer size or count then we can't work
+        assert(_info.total_dma_buf_size == _buffers * _bufferWords * 4);
         _totalAvailable = _info.total_dma_buf_size;
 
         // Prefill silence and calculate how bug we really have
@@ -215,7 +224,7 @@ public:
             .on_sent = _onSent,
             .on_send_q_ovf = nullptr
         };
-        i2s_channel_register_event_callback(_tx_handle, &_cbs, (void *)this);
+        assert(ESP_OK == i2s_channel_register_event_callback(_tx_handle, &_cbs, (void *)this));
         xTaskCreate(_taskShim, "BackgroundAudioI2S", 8192, (void*)this, 2, &_taskHandle);
         _running = ESP_OK == i2s_channel_enable(_tx_handle);
         return _running;
@@ -412,8 +421,6 @@ public:
         @return Number of frames available.  May not be completely accurate
     */
     int availableForWrite() override {
-        i2s_chan_info_t _info;
-        i2s_channel_get_info(_tx_handle, &_info);
         return (int)_available.load(std::memory_order_acquire) / 4;
     }
 

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -393,7 +393,7 @@ public:
         size_t cumWritten = 0;
         while (size) {
             size_t written = 0;
-            i2s_channel_write(_tx_handle, buffer, size, &written, 0);
+            i2s_channel_write(_tx_handle, buffer, size, &written, 100);
             _saturating_sub_available((uint32_t)written);
             buffer += written;
             size -= written;


### PR DESCRIPTION
ESP32 i2s_channel_write seems to return after filling the current DMA buffer, even if free add'l buffers could be written.  Move the retry from MP3 decode to the ESP32I2S internal so all codecs can benefit.

See #65 for discussion

Also add a basic assert() to verify that the app logic itself guarantees we can write any buffer we generate.