### PR TITLE
Fix availableForWrite logic, ESP32I2S output

### DIFF
--- a/src/BackgroundAudioAAC.h
+++ b/src/BackgroundAudioAAC.h
@@ -323,7 +323,7 @@ private:
     }
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen) {
+        while (_out->availableForWrite() >= (int)framelen * 2 * sizeof(int16_t)) {
             if (_paused) {
                 bzero((uint8_t *)_outSample, _outSamples * 2 * sizeof(int16_t));
             } else {

--- a/src/BackgroundAudioAAC.h
+++ b/src/BackgroundAudioAAC.h
@@ -323,7 +323,7 @@ private:
     }
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen * 2 * sizeof(int16_t)) {
+        while (_out->availableForWrite() >= (int)(framelen * 2 * sizeof(int16_t))) {
             if (_paused) {
                 bzero((uint8_t *)_outSample, _outSamples * 2 * sizeof(int16_t));
             } else {

--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -342,7 +342,7 @@ private:
     }
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen) {
+        while (_out->availableForWrite() >= (int)framelen * 4) {
             if (_paused) {
                 bzero(_synth.pcm.samplesX, _synth.pcm.length * 4);
             } else {

--- a/src/BackgroundAudioMP3.h
+++ b/src/BackgroundAudioMP3.h
@@ -342,7 +342,7 @@ private:
     }
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen * 4) {
+        while (_out->availableForWrite() >= (int)(framelen * 4)) {
             if (_paused) {
                 bzero(_synth.pcm.samplesX, _synth.pcm.length * 4);
             } else {

--- a/src/BackgroundAudioMixer.h
+++ b/src/BackgroundAudioMixer.h
@@ -498,7 +498,7 @@ private:
         @brief Pumps all inputs to get their next block of data or silence and sends it to the real output device
     */
     void pump() {
-        while (_out->availableForWrite() >= (int)_outWords * 4) {
+        while (_out->availableForWrite() >= (int)(_outWords * 4)) {
             generateOneFrame();
             assert(_out->write((uint8_t *)_outBuff, _outWords * 4) == _outWords * 4);
         }

--- a/src/BackgroundAudioMixer.h
+++ b/src/BackgroundAudioMixer.h
@@ -498,9 +498,9 @@ private:
         @brief Pumps all inputs to get their next block of data or silence and sends it to the real output device
     */
     void pump() {
-        while (_out->availableForWrite() >= (int)_outWords) {
+        while (_out->availableForWrite() >= (int)_outWords * 4) {
             generateOneFrame();
-            _out->write((uint8_t *)_outBuff, _outWords * 4);
+            assert(_out->write((uint8_t *)_outBuff, _outWords * 4) == _outWords * 4);
         }
     }
 

--- a/src/BackgroundAudioSpeech.h
+++ b/src/BackgroundAudioSpeech.h
@@ -409,7 +409,7 @@ private:
     }
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen * 4) {
+        while (_out->availableForWrite() >= (int)(framelen * 4)) {
             if (!_frameLen && !_paused) {
                 generateOneFrame();
             }

--- a/src/BackgroundAudioSpeech.h
+++ b/src/BackgroundAudioSpeech.h
@@ -409,7 +409,7 @@ private:
     }
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen) {
+        while (_out->availableForWrite() >= (int)framelen * 4) {
             if (!_frameLen && !_paused) {
                 generateOneFrame();
             }

--- a/src/BackgroundAudioWAV.h
+++ b/src/BackgroundAudioWAV.h
@@ -420,7 +420,7 @@ underflow:
 
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen) {
+        while (_out->availableForWrite() >= (int)framelen * 2 * sizeof(int16_t)) {
             if (_paused) {
                 bzero((uint8_t *)_outSample, framelen * 2 * sizeof(int16_t));
             } else {
@@ -429,7 +429,7 @@ underflow:
                     _out->setFrequency(_sampleRate);
                 }
             }
-            _out->write((uint8_t *)_outSample, framelen * 2 * sizeof(int16_t));
+            assert(_out->write((uint8_t *)_outSample, framelen * 2 * sizeof(int16_t)) == framelen * 2 * sizeof(int16_t));
         }
     }
 

--- a/src/BackgroundAudioWAV.h
+++ b/src/BackgroundAudioWAV.h
@@ -420,7 +420,7 @@ underflow:
 
 
     void pump() {
-        while (_out->availableForWrite() >= (int)framelen * 2 * sizeof(int16_t)) {
+        while (_out->availableForWrite() >= (int)(framelen * 2 * sizeof(int16_t))) {
             if (_paused) {
                 bzero((uint8_t *)_outSample, framelen * 2 * sizeof(int16_t));
             } else {

--- a/src/ESP32I2SAudio.h
+++ b/src/ESP32I2SAudio.h
@@ -421,7 +421,7 @@ public:
         @return Number of frames available.  May not be completely accurate
     */
     int availableForWrite() override {
-        return (int)_available.load(std::memory_order_acquire) / 4;
+        return (int)_available.load(std::memory_order_acquire);
     }
 
 protected:


### PR DESCRIPTION
availableForWrite should always return the number of bytes that can be written to the output, not the number of words (i.e. it's the same definition as Arduino Stream::availableForWrite)

Remove the /4 adjustment in the ESP32I2SOutput and fix the buffer-available-logic in the codecs.