### PR TITLE
ESP32PDMAudio save samplerate when not running

### DIFF
--- a/src/ESP32PDMAudio.h
+++ b/src/ESP32PDMAudio.h
@@ -78,8 +78,8 @@ public:
             i2s_channel_disable(_tx_handle);
             i2s_channel_reconfig_pdm_tx_clock(_tx_handle, &clk_cfg);
             i2s_channel_enable(_tx_handle);
-            _sampleRate = freq;
         }
+        _sampleRate = freq;
         return true;
     }
 


### PR DESCRIPTION
Fixes #80

The PDM object wasn't properly recording a change to the samplerate before it started running, leading to eSpeak to generate at 22khz by playback at 44.1khz.