### PR TITLE
Make Speech use lower prio IRQ on Pico

### DIFF
--- a/src/BackgroundAudioSpeech.h
+++ b/src/BackgroundAudioSpeech.h
@@ -443,7 +443,7 @@ public:
                 bzero(_frame, sizeof(_frame));
                 assert(_out->write((uint8_t *)_frame, sizeof(_frame)) == sizeof(_frame));
             } else {
-                assert(_out->write((uint8_t *)_frame, _frameLen * 4) == _frameLen * 4);
+                assert(_out->write((uint8_t *)_frame, _frameLen * 4) == (size_t)(_frameLen * 4));
                 _frameLen = 0;
             }
         }


### PR DESCRIPTION
Same as MP3 or AAC, speech can take large amounts of CPU.  Use the same lower-prio IRQ setup as AAC or MP3